### PR TITLE
deviceで認証、new&createメソッドは認証ユーザのみ実行可能

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,5 @@
+linters:
+  RuboCop:
+    enabled: true
+    # Use the rubocop config specified in your project
+    config: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  Exclude:
+    - "**/*.haml"
+  TargetRubyVersion: 3.2
+  NewCops: enable
+
+Lint/EmptyFile:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '3.2.3'
 # ADDITIONAL GEMS
 gem 'bootstrap', '~> 5.3.2'
 gem 'devise'
+gem 'dotenv-rails'
 gem 'haml-rails'
 gem 'html2haml'
 gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '3.2.3'
 
 # ADDITIONAL GEMS
 gem 'bootstrap', '~> 5.3.2'
+gem 'devise'
 gem 'haml-rails'
 gem 'html2haml'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -93,6 +94,12 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    devise (4.9.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     erubi (1.12.0)
     erubis (2.7.0)
     execjs (2.9.1)
@@ -166,6 +173,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     pg (1.5.6)
     popper_js (2.11.8)
     psych (5.1.2)
@@ -211,6 +219,9 @@ GEM
     regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rexml (3.2.6)
     ruby_parser (3.21.0)
       racc (~> 1.5)
@@ -250,6 +261,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -276,6 +289,7 @@ DEPENDENCIES
   bootstrap (~> 5.3.2)
   capybara
   debug
+  devise
   haml-rails
   html2haml
   importmap-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (3.1.0)
+    dotenv-rails (3.1.0)
+      dotenv (= 3.1.0)
+      railties (>= 6.1)
     erubi (1.12.0)
     erubis (2.7.0)
     execjs (2.9.1)
@@ -290,6 +294,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  dotenv-rails
   haml-rails
   html2haml
   importmap-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  # 以下追記
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!, only: %i[new create]
+
   def index
     @posts = Post.all.order(created_at: :desc)
     @post = Post.new
@@ -10,12 +12,13 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.new(post_params)
+    @post = current_user.posts.build(post_params)
+    puts "Post Params: #{post_params.inspect}" # パラメータの出力
     if @post.save
       redirect_to posts_path, notice: 'Post was successfully created.'
     else
-      @posts = Post.all.order(created_at: :desc)
-      render :timeline
+      puts "Post could not be saved. Errors: #{@post.errors.full_messages}" # 保存失敗とエラーメッセージのログ出力
+      redirect_to posts_path, alert: 'Post could not be created.'
     end
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
+//= require rails-ujs
 
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails";

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ApplicationRecord
   validates :content, length: { maximum: 140 }
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,39 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         authentication_keys: [:username] # 認証のキーをメールから名前へ
+
+  validates_uniqueness_of :username
+  validates_presence_of :username
+
+  # usernameを利用してログイン
+  def self.find_first_by_auth_conditions(warden_conditions)
+    conditions = warden_conditions.dup
+    if username = conditions.delete(:login)
+      where(conditions).where(['username = :value', { value: username }]).first
+    else
+      where(conditions).first
+    end
+  end
+
+  def email_required?
+    false
+  end
+
+  def email_changed?
+    false
+  end
+
+  def will_save_change_to_email?
+    false
+  end
+
+  # バリデーション（アルファベットのみ、スペース禁止、20文字以内）
+  validates :username, presence: true, length: { maximum: 20 },
+                       format: { with: /\A[a-zA-Z]*\z/, message: 'only allows letters' }
+
+  # ユーザーは複数のPostを持ち、ユーザーが削除されたらpostも削除
+  has_many :posts, dependent: :destroy
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %meta{content: 'width=device-width,initial-scale=1', name: 'viewport'}/
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', "data-turbo-track": 'reload'
+    = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
-  %body
+  %body.d-flex.flex-column.justify-content-center.align-items-center
     = yield

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -31,3 +31,6 @@
       %p
         = post.created_at
       %hr.w-50
+
+  / Debug Information
+  %pre= debug(@post)

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,19 +1,20 @@
-.container.d-flex.flex-column.justify-content-center.align-items-center
-  %h1.text-center.font-weight-bold.mb-4.border-bottom 新規投稿
+-# haml-lint:disable IdNames
+%h1.text-center.font-weight-bold.mb-4.border-bottom
+  新規投稿
 
-  = form_with model: @post, local: true, class: 'flex d-flex flex-column align-items-center w-50' do |f|
-    - if @post.errors.any?
-      #error_explanation
-        %h2= `#{pluralize(@post.errors.count, 'error')} prohibited this post from being saved:`
-        %ul
-          - @post.errors.full_messages.each do |message|
-            %li= message
+.flex.d-flex.flex-column.align-items-center.justify-content-center
+= form_with model: @post do |f|
+  .field.mb-3.w-100
+    = f.label :content, class: 'form-label'
+    = f.text_area :content, class: 'form-control', maxlength: 140
+  .actions.mt-3.d-flex.justify-content-center
+    = f.submit 'Post', class: 'btn btn-primary'
 
-    .field.flex.mb-3.w-100
-      = f.label :content
-      = f.text_area :content, maxlength: 140, class: 'form-control form-control-lg'
+.d-flex.justify-content-center.mt-4
+  = link_to '投稿一覧', posts_path, class: 'btn btn-secondary'
 
-    .actions
-      = f.submit 'Postを作成', class: 'btn btn-primary mt-3'
-
-  = link_to '投稿一覧', posts_path, class: 'btn btn-secondary mt-4'
+/ # ログインしている場合はログアウトボタンを表示
+- if user_signed_in?
+  .d-flex.justify-content-center.mt-4
+    = link_to 'ログアウト', destroy_user_session_path,
+              data: { turbo_method: :delete }, class: 'btn btn-secondary'

--- a/app/views/posts/timeline.html.haml
+++ b/app/views/posts/timeline.html.haml
@@ -1,12 +1,11 @@
-.container.d-flex.flex-column.justify-content-center.align-items-center
-  %h1.text-center.font-weight-bold.mb-4.border-bottom 全体タイムライン
+%h1.text-center.font-weight-bold.mb-4.border-bottom 全体タイムライン
 
-  = link_to '新規投稿', '/posts/new', class: 'btn btn-primary mb-4'
+= link_to '新規投稿', new_post_path, class: 'btn btn-primary mb-4'
 
-  - @posts.each do |post|
-    .post.flex.d-flex.flex-column.align-items-center.w-50
-      %p
-        = post.content
-      %p
-        = post.created_at
-      %hr.w-50
+- @posts.each do |post|
+  .post.flex.d-flex.flex-column.align-items-center.w-50
+    %p
+      = post.content
+    %p
+      = post.created_at
+    %hr.w-50

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend confirmation instructions
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render "users/shared/error_messages", resource: resource
+  .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "username", value: resource.username
+  .actions
+    = f.submit "Resend confirmation instructions"
+= render "users/shared/links"

--- a/app/views/users/mailer/confirmation_instructions.html.haml
+++ b/app/views/users/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p
+  Welcome #{@email}!
+%p You can confirm your account email through the link below:
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/users/mailer/email_changed.html.haml
+++ b/app/views/users/mailer/email_changed.html.haml
@@ -1,0 +1,8 @@
+%p
+  Hello #{@email}!
+- if @resource.try(:unconfirmed_email?)
+  %p
+    We're contacting you to notify you that your email is being changed to #{@resource.unconfirmed_email}.
+- else
+  %p
+    We're contacting you to notify you that your email has been changed to #{@resource.email}.

--- a/app/views/users/mailer/password_change.html.haml
+++ b/app/views/users/mailer/password_change.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hello #{@resource.email}!
+%p We're contacting you to notify you that your password has been changed.

--- a/app/views/users/mailer/reset_password_instructions.html.haml
+++ b/app/views/users/mailer/reset_password_instructions.html.haml
@@ -1,0 +1,6 @@
+%p
+  Hello #{@resource.email}!
+%p Someone has requested a link to change your password. You can do this through the link below.
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+%p If you didn't request this, please ignore this email.
+%p Your password won't change until you access the link above and create a new one.

--- a/app/views/users/mailer/unlock_instructions.html.haml
+++ b/app/views/users/mailer/unlock_instructions.html.haml
@@ -1,0 +1,5 @@
+%p
+  Hello #{@resource.email}!
+%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+%p Click the link below to unlock your account:
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/app/views/users/passwords/edit.html.haml
+++ b/app/views/users/passwords/edit.html.haml
@@ -1,0 +1,19 @@
+%h2 Change your password
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = render "users/shared/error_messages", resource: resource
+  = f.hidden_field :reset_password_token
+  .field
+    = f.label :password, "New password"
+    %br/
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+      %br/
+    = f.password_field :password, autofocus: true, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation, "Confirm new password"
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Change my password"
+= render "users/shared/links"

--- a/app/views/users/passwords/new.html.haml
+++ b/app/views/users/passwords/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Forgot your password?
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = render "users/shared/error_messages", resource: resource
+  .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "username"
+  .actions
+    = f.submit "Send me reset password instructions"
+= render "users/shared/links"

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -1,0 +1,33 @@
+%h2
+  Edit #{resource_name.to_s.humanize}
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = render "users/shared/error_messages", resource: resource
+  .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "username"
+  .field
+    = f.label :password
+    %i (leave blank if you don't want to change it)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+    - if @minimum_password_length
+      %br/
+      %em
+        = @minimum_password_length
+        characters minimum
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .field
+    = f.label :current_password
+    %i (we need your current password to confirm your changes)
+    %br/
+    = f.password_field :current_password, autocomplete: "current-password"
+  .actions
+    = f.submit "Update"
+%h3 Cancel my account
+%div
+  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,0 +1,21 @@
+%h2 Sign up
+= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = render "users/shared/error_messages", resource: resource
+  .field
+    = f.label :username, 'ユーザー名 (アルファベットのみ、スペース禁止、20文字以内)'
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "username"
+  .field
+    = f.label :password
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Sign up"
+= render "users/shared/links"

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -1,0 +1,17 @@
+%h2 Log in
+= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "username"
+  .field
+    = f.label :password
+    %br/
+    = f.password_field :password, autocomplete: "current-password"
+  - if devise_mapping.rememberable?
+    .field
+      = f.check_box :remember_me
+      = f.label :remember_me
+  .actions
+    = f.submit "Log in"
+= render "users/shared/links"

--- a/app/views/users/shared/_error_messages.html.haml
+++ b/app/views/users/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation{"data-turbo-cache" => "false"}
+    %h2
+      = I18n.t("errors.messages.not_saved",                 |
+        count: resource.errors.count,                       |
+        resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/users/shared/_links.html.haml
+++ b/app/views/users/shared/_links.html.haml
@@ -1,0 +1,19 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
+  %br/
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
+  %br/
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:username) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }
+    %br/

--- a/app/views/users/unlocks/new.html.haml
+++ b/app/views/users/unlocks/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend unlock instructions
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = render "users/shared/error_messages", resource: resource
+  .field
+    = f.label :username
+    %br/
+    = f.text_field :username, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Resend unlock instructions"
+= render "users/shared/links"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,4 @@ pin_all_from 'app/javascript/controllers', under: 'controllers'
 # ADDITIONAL PACKAGES
 pin 'bootstrap', to: 'bootstrap.min.js', preload: true
 pin '@popperjs/core', to: 'popper.js', preload: true
+pin '@hotwired/turbo-rails', to: 'turbo.js'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '0f5c4e94dfed63fec2bd46307b1b3f47b0566237c41ad57667846543ccb42a3663c4a7b3563d88f9f109dae4a70fc626c2a7274f4ef3f730fa8892195b296d8d'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:username]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:username]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'd49410960f6b0c5fea54ae577606f7ccded2d109ba6a0e6114512b5167f36493112ffb521c59b8e25b32236039909ed85cc7c24e05ba06ac37caa7061830b527'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  config.scoped_views = true
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,8 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '0f5c4e94dfed63fec2bd46307b1b3f47b0566237c41ad57667846543ccb42a3663c4a7b3563d88f9f109dae4a70fc626c2a7274f4ef3f730fa8892195b296d8d'
-
+  config.secret_key = ENV.fetch('DEVISE_SECRET_KEY')
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your UserName has been successfully confirmed."
+      send_instructions: "You will receive an username with instructions for how to confirm your UserName in a few minutes."
+      send_paranoid_instructions: "If your UserName exists in our database, you will receive an username with instructions for how to confirm your UserName in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your UserName before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      username_changed:
+        subject: "Username Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your UserName exists in our database, you will receive a password recovery link at your UserName in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your UserName. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new UserName. Please check your email and follow the confirmation link to confirm your new UserName."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
-  resources :posts, only: %i[index create]
-  get 'posts/new', to: 'posts#new'
-  get 'posts/timeline', to: 'posts#index'
+  devise_for :users
+  resources :posts, only: %i[index new create]
+  get 'timeline', to: 'posts#index'
+  root 'posts#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20240315112237_devise_create_users.rb
+++ b/db/migrate/20240315112237_devise_create_users.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :username, null: false, default: '' # ユーザー名
+      t.string :encrypted_password, null: false, default: ''
+
+      ## User information
+      t.string :profile, limit: 200 # プロフィール
+      t.string :blog_url            # ブログURL
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :username,              unique: true # ユーザー名のインデックス
+    add_index :users, :reset_password_token,  unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20240315152559_add_user_id_to_posts.rb
+++ b/db/migrate/20240315152559_add_user_id_to_posts.rb
@@ -1,0 +1,5 @@
+class AddUserIdToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :posts, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_12_113032) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_15_152559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,23 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_113032) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "username", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "profile", limit: 200
+    t.string "blog_url"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
+  add_foreign_key "posts", "users"
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
https://github.com/githuno/LEARN-rails-gakusyu1/issues/11
https://github.com/githuno/LEARN-rails-gakusyu1/issues/12

1. deviceの導入
2. usersテーブルの追加とバリデーション
　- emailの無効化 
3. usersとpostsの関連付け
4. postsへのuser_idテーブル追加
5. DELETEメソッドの有効化
6. new＆createのbeforeアクションに`authenticate_user!`を追加